### PR TITLE
Fix/138

### DIFF
--- a/src/core/components/global/deaktopMenuList.tsx
+++ b/src/core/components/global/deaktopMenuList.tsx
@@ -4,18 +4,27 @@ import { useLogout } from "@/core/hooks/useLogout";
 import { useAuthStore } from "@/store/authStore";
 import { redirectToDashboard } from "@/utils/authUtils";
 
-export default function DesktopMenuList({ menuOpen, accountButtonRef }: { menuOpen: boolean; accountButtonRef: RefObject<HTMLDivElement | null> }) {
+export default function DesktopMenuList({
+  menuOpen,
+  setMenuOpen,
+  accountButtonRef,
+}: {
+  menuOpen: boolean;
+  setMenuOpen: (menuOpen: boolean) => void;
+  accountButtonRef: RefObject<HTMLDivElement | null>;
+}) {
   const [position, setPosition] = useState({ top: -1000, right: 0 });
   const { handleLogout } = useLogout();
   const navigate = useNavigate();
   const role = useAuthStore((state) => state.role);
+
   const handleNavigation = useCallback(
     (path: string) => {
-      if (menuOpen) {
-        navigate(path);
-      }
+      console.log("Click:", path);
+      setMenuOpen(false);
+      navigate(path);
     },
-    [menuOpen, navigate]
+    [setMenuOpen, navigate]
   );
   useEffect(() => {
     const updatePosition = () => {
@@ -35,31 +44,62 @@ export default function DesktopMenuList({ menuOpen, accountButtonRef }: { menuOp
       window.removeEventListener("resize", updatePosition);
     };
   }, [accountButtonRef]);
-
+  useEffect(() => {
+    if (menuOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "auto";
+    }
+  }, [menuOpen]);
   return (
     <div
-      className={`fixed z-99 bg-white transition-opacity ${menuOpen ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"}`}
+      className={`fixed z-50 bg-white transition-opacity ${menuOpen ? "pointer-events-auto block opacity-100" : "hidden opacity-0"}`}
       style={{
-        top: menuOpen ? `${position.top + 10}px` : "-1000px",
+        top: `${position.top + 10}px`,
         right: `${position.right}px`,
       }}
     >
       <ul className="flex flex-col gap-3 overflow-hidden rounded-md bg-white py-2 shadow-sm">
-        <li className="cursor-pointer px-12 py-2 hover:bg-neutral-100" onClick={() => handleNavigation("/user")}>
+        <li
+          className="cursor-pointer px-12 py-2 hover:bg-neutral-100"
+          onClick={() => {
+            handleNavigation("/user");
+          }}
+        >
           會員中心
         </li>
-        <li className="cursor-pointer px-12 py-2 hover:bg-neutral-100" onClick={() => handleNavigation("/company")}>
+        <li
+          className="cursor-pointer px-12 py-2 hover:bg-neutral-100"
+          onClick={() => {
+            handleNavigation("/company");
+          }}
+        >
           舉辦演唱會
         </li>
-        <li className="cursor-pointer px-12 py-2 hover:bg-neutral-100" onClick={() => handleNavigation("/user/about/history")}>
+        <li
+          className="cursor-pointer px-12 py-2 hover:bg-neutral-100"
+          onClick={() => {
+            handleNavigation("/user/about/history");
+          }}
+        >
           查看參與的演唱會
         </li>
         {(role === "admin" || role === "superuser") && (
-          <li className="cursor-pointer px-12 py-2 hover:bg-neutral-100" onClick={redirectToDashboard}>
+          <li
+            className="cursor-pointer px-12 py-2 hover:bg-neutral-100"
+            onClick={() => {
+              redirectToDashboard();
+            }}
+          >
             後台管理
           </li>
         )}
-        <li className="cursor-pointer px-12 py-2 hover:bg-neutral-100" onClick={handleLogout}>
+        <li
+          className="cursor-pointer px-12 py-2 hover:bg-neutral-100"
+          onClick={() => {
+            handleLogout();
+          }}
+        >
           登出
         </li>
       </ul>

--- a/src/core/components/global/deaktopSearchBar.tsx
+++ b/src/core/components/global/deaktopSearchBar.tsx
@@ -15,7 +15,7 @@ export default function DesktopSearchBar({
   return (
     <>
       {desktopSearchBlock && (
-        <div className="fixed top-20 left-1/2 h-[128px] w-full max-w-[1075px] -translate-x-1/2 transform rounded-[24px] bg-white p-6 shadow-sm lg:block">
+        <div className="fixed top-20 left-1/2 z-99 h-[128px] w-full max-w-[1075px] -translate-x-1/2 transform rounded-[24px] bg-white p-6 shadow-sm lg:block">
           <div className="flex h-full items-center justify-between gap-x-2 p-2">
             <div onClick={() => setDesktopSearchBlock(false)} className="flex w-[40px] cursor-pointer items-center justify-center">
               <Icon icon="my-close" className="text-2xl" />

--- a/src/core/components/global/header.tsx
+++ b/src/core/components/global/header.tsx
@@ -104,7 +104,7 @@ export default function Header() {
             searchText={searchText}
             setSearchText={setSearchText}
           />
-          <DesktopMenuList menuOpen={menu} accountButtonRef={accountButtonRef} />
+          <DesktopMenuList menuOpen={menu} setMenuOpen={setMenu} accountButtonRef={accountButtonRef} />
         </div>
 
         {/* 手機版 */}

--- a/src/core/components/ui/singleDatePicker.tsx
+++ b/src/core/components/ui/singleDatePicker.tsx
@@ -16,6 +16,8 @@ interface SingleDatePickerProps {
   format?: string;
   defaultMonth?: Date;
   disabled?: boolean;
+  disableFuture?: boolean;
+  disablePast?: boolean;
 }
 
 export function SingleDatePicker({
@@ -26,6 +28,8 @@ export function SingleDatePicker({
   format = "YYYY-MM-DD",
   defaultMonth,
   disabled,
+  disableFuture,
+  disablePast,
 }: SingleDatePickerProps) {
   return (
     <Popover>
@@ -48,6 +52,11 @@ export function SingleDatePicker({
           }}
           defaultMonth={date || (defaultMonth ? dayjs(defaultMonth).toDate() : undefined)}
           required
+          disabled={(date) => {
+            if (disableFuture && dayjs(date).isAfter(dayjs(), "day")) return true;
+            if (disablePast && dayjs(date).isBefore(dayjs(), "day")) return true;
+            return false;
+          }}
         />
       </PopoverContent>
     </Popover>

--- a/src/core/hooks/useImportImages.ts
+++ b/src/core/hooks/useImportImages.ts
@@ -6,17 +6,17 @@ const images = import.meta.glob("@/assets/images/**/*.{png,jpg,jpeg,gif,svg}", {
   eager: true,
   import: "default",
 });
+
 export function useImportImages(imagePath: string[]): ImageType {
   return useMemo(() => {
     const importedImages: ImageType = {};
 
     imagePath.forEach((path) => {
-      const fullPath = `/src/assets/images/${path}`;
-      const image = images[fullPath];
-      if (image) {
-        importedImages[path] = fullPath as string;
+      const matchedKey = Object.keys(images).find((key) => key.endsWith(`/assets/images/${path}`));
+      if (matchedKey && images[matchedKey]) {
+        importedImages[path] = images[matchedKey] as string;
       } else {
-        console.warn(`圖片路徑錯誤或找不到: ${fullPath}`);
+        console.warn(`圖片找不到: ${path}`);
       }
     });
 

--- a/src/pages/comm/views/components/signupSection.tsx
+++ b/src/pages/comm/views/components/signupSection.tsx
@@ -8,6 +8,8 @@ import { useRequest } from "@/core/hooks/useRequest";
 import { useToast } from "@/core/hooks/useToast";
 import { useAuthStore } from "@/store/authStore";
 import { useNavigate } from "react-router-dom";
+import { SingleDatePicker } from "@/core/components/ui/singleDatePicker";
+
 export function SignupSection() {
   const { toast } = useToast();
   const setAuth = useAuthStore((state) => state.setAuth);
@@ -24,7 +26,7 @@ export function SignupSection() {
   });
   // 檢查密碼是否一致
   const [isCheckedPassword, setIsCheckedPassword] = useState(false);
-  const { email, setEmail, isValid, errorMessage } = useEmailValidation();
+  const { setEmail, isValid, errorMessage: emailErrorMessage } = useEmailValidation();
   const [error, setError] = useState({
     name: {
       error: false,
@@ -143,10 +145,11 @@ export function SignupSection() {
               setSignupData({ ...signupData, email: e.target.value });
               setEmail(e.target.value);
             }}
+            error={emailErrorMessage ? true : false}
+            errorMessage={emailErrorMessage}
           />
-          {!isValid && email && <p className="absolute top-full left-0 mt-1 text-sm text-red-500">{errorMessage}</p>}
         </div>
-        <div className="flex w-full">
+        <div className="flex w-full flex-col items-center lg:flex-row">
           <Input
             type="tel"
             label="手機號碼"
@@ -157,13 +160,27 @@ export function SignupSection() {
               checkPhone(e);
             }}
           />
-          <Input
-            type="date"
-            label="出生日期"
-            id="birthday"
-            placeholder="年 月 日"
-            className="ml-2"
-            onChange={(e) => setSignupData({ ...signupData, birthday: e.target.value })}
+          <SingleDatePicker
+            inputClassName="ml-1"
+            date={signupData.birthday ? new Date(signupData.birthday) : null}
+            setDate={(date) =>
+              setSignupData((prev) => ({
+                ...prev,
+                birthday: date
+                  ? date
+                      .toLocaleDateString("zh-TW", {
+                        year: "numeric",
+                        month: "2-digit",
+                        day: "2-digit",
+                      })
+                      .split("/")
+                      .join("-")
+                  : "",
+              }))
+            }
+            defaultMonth={new Date(new Date().setFullYear(new Date().getFullYear() - 20))}
+            placeholder="請選擇出生年月日"
+            disableFuture
           />
         </div>
         {error["phone"].error && <p className="text-sm text-red-500">{error["phone"].errorMessage}</p>}

--- a/src/pages/company/components/companyInfoSection.tsx
+++ b/src/pages/company/components/companyInfoSection.tsx
@@ -22,7 +22,7 @@ const formSchema = z.object({
   orgPhone: z
     .string()
     .trim()
-    .regex(/^0\d{1}-\d{9,10}$/, "必須為 0X-XXXXXXX 格式, 共10碼或11碼"),
+    .regex(/^0\d{8,9}$/, "必須為 0 開頭的 9 或 10 碼數字"),
   orgWebsite: z.string().trim().optional(),
 });
 type FormValues = z.infer<typeof formSchema>;
@@ -88,13 +88,13 @@ export default function CompanyInfoSection({
     }
   }, [companyInfoData, reset]);
 
-  const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    let value = e.target.value.replace(/\D/g, ""); // 移除所有非數字字符
-    if (value.length > 1) {
-      value = value.slice(0, 2) + "-" + value.slice(2); // 在第二個字符後插入 '-'
-    }
-    e.target.value = value;
-  };
+  // const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  //   let value = e.target.value.replace(/\D/g, ""); // 移除所有非數字字符
+  //   if (value.length > 1) {
+  //     value = value.slice(0, 2) + "-" + value.slice(2); // 在第二個字符後插入 '-'
+  //   }
+  //   e.target.value = value;
+  // };
 
   //串接 更新公司的詳細資料
   const { useUpdate: requestUpdateCompany } = useRequest({
@@ -217,7 +217,6 @@ export default function CompanyInfoSection({
                         {...register(item.field)}
                         error={!!errors[item.field]}
                         errorMessage={errors[item.field]?.message}
-                        onChange={item.field === "orgPhone" ? handlePhoneChange : undefined}
                       />
                     ) : (
                       <div className="p-3 lg:p-5">

--- a/src/pages/concerts/components/BuyTicketSection.tsx
+++ b/src/pages/concerts/components/BuyTicketSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import BeforeBuyTicket from "./BeforeBuyTicket";
 import ConcertSessionSection from "./ConcertSessionSection";
 import PrecautionAndNeedtoKnow from "./PrecautionAndNeedtoKnow";
@@ -10,13 +10,13 @@ import { formatNumberToPrice } from "@/utils/formatToPrice";
 import { useBuyTicketContext } from "../hook/useBuyTicketContext";
 import { useToast } from "@/core/hooks/useToast";
 import { useRequest } from "@/core/hooks/useRequest";
-import { ticketTypeItem } from "../types/ConcertData";
+// import { ticketTypeItem } from "../types/ConcertData";
 import { Concert } from "@/pages/comm/types/Concert";
 import { CreateOrderData, PaymentResultResponse } from "../types/BuyTicket";
-import LoadingSpin from "@/core/components/global/loadingSpin";
+// import LoadingSpin from "@/core/components/global/loadingSpin";
 import { AxiosResponse } from "axios";
 
-export default function BuyTicketSection({ concertData, concertSessionId }: { concertData: Concert; concertSessionId: string }) {
+export default function BuyTicketSection({ concertData }: { concertData: Concert }) {
   const { selectedSession, selectedTickets, buyerInfo, validateBuyerInfo, newOrderInfo, setNewOrderInfo } = useBuyTicketContext();
   // chooseSession+TicketType 選擇場次及票種 --> insertBuyerInfo 填寫購票人資訊
   const [buyTicketStep, setBuyTicketStep] = useState("chooseSession");
@@ -27,36 +27,38 @@ export default function BuyTicketSection({ concertData, concertSessionId }: { co
     setTotalPrice(selectedTickets.reduce((acc, ticket) => acc + ticket.ticketPrice * ticket.quantity, 0));
   }, [selectedSession, selectedTickets, buyerInfo]);
   // 取得 取得票券資訊
-  interface ticketData {
-    tickets: ticketTypeItem[];
-  }
+  // interface ticketData {
+  //   tickets: ticketTypeItem[];
+  // }
+  // useEffect(() => {
+  //   console.log("selectedSession:", selectedSession);
+  // }, [selectedSession]);
+  // const { useGet } = useRequest<ticketData>({
+  //   queryKey: concertSessionId ? [concertSessionId] : [],
+  //   url: `/api/v1/ticket`,
+  // });
 
-  const { useGet } = useRequest<ticketData>({
-    queryKey: concertSessionId ? [concertSessionId] : [],
-    url: `/api/v1/ticket`,
-  });
+  // const { data, error, isLoading } = useGet(concertSessionId, !!concertSessionId && concertSessionId !== "undefined");
 
-  const { data, error, isLoading } = useGet(concertSessionId, !!concertSessionId && concertSessionId !== "undefined");
+  // // 使用 useMemo 處理 sessionTicketData
+  // const sessionTicketData = useMemo(() => {
+  //   if (!data) return [];
+  //   if ("tickets" in data) return data.tickets;
+  //   if ("data" in data && "tickets" in (data.data as unknown as { tickets: ticketTypeItem[] }))
+  //     return (data.data as unknown as { tickets: ticketTypeItem[] }).tickets;
+  //   return [];
+  // }, [data]);
 
-  // 使用 useMemo 處理 sessionTicketData
-  const sessionTicketData = useMemo(() => {
-    if (!data) return [];
-    if ("tickets" in data) return data.tickets;
-    if ("data" in data && "tickets" in (data.data as unknown as { tickets: ticketTypeItem[] }))
-      return (data.data as unknown as { tickets: ticketTypeItem[] }).tickets;
-    return [];
-  }, [data]);
-
-  // 處理錯誤
-  useEffect(() => {
-    if (error) {
-      toast({
-        variant: "destructive",
-        title: "錯誤",
-        description: error.message || "發生錯誤，請稍後再試",
-      });
-    }
-  }, [error, toast]);
+  // // 處理錯誤
+  // useEffect(() => {
+  //   if (error) {
+  //     toast({
+  //       variant: "destructive",
+  //       title: "錯誤",
+  //       description: error.message || "發生錯誤，請稍後再試",
+  //     });
+  //   }
+  // }, [error, toast]);
 
   //創建訂單
   const { useCreate: requestCreateOrder } = useRequest({
@@ -162,39 +164,30 @@ export default function BuyTicketSection({ concertData, concertSessionId }: { co
   return (
     <div className="flex h-full flex-col items-center gap-2 px-4 lg:gap-8 lg:px-12">
       <div className="mx-auto grid h-[70%] w-full grid-cols-1 lg:w-[90%] lg:grid-cols-2">
-        {isLoading && <LoadingSpin />}
-        {!isLoading && (
-          <>
-            {/* 演唱會資訊 */}
-            <div className="col-span-1 h-[70%] space-y-2 lg:px-3">
-              <div className="flex items-center justify-between">
-                <div className="text-lg font-semibold">{concertData.conTitle}</div>
-                <div>
-                  {concertData.eventStartDate} - {concertData.eventEndDate}
-                </div>
-              </div>
-              <div className="relative h-[350px] w-full">
-                <img src={concertData.imgBanner} alt={concertData.conTitle} className="h-full w-full object-cover" />
-              </div>
-              <div className="my-4">{buyTicketStep === "chooseSession" ? <BeforeBuyTicket /> : <PrecautionAndNeedtoKnow />}</div>
+        {/* 演唱會資訊 */}
+        <div className="col-span-1 h-[70%] space-y-2 lg:px-3">
+          <div className="flex items-center justify-between">
+            <div className="text-lg font-semibold">{concertData.conTitle}</div>
+            <div>
+              {concertData.eventStartDate} - {concertData.eventEndDate}
             </div>
-            <div className="col-span-1 h-[30%] space-y-2 lg:px-3">
-              <div className="flex justify-center gap-2">
-                {/* 場次選擇 */}
-                {buyTicketStep === "chooseSession" && (
-                  <ConcertSessionSection
-                    sessionData={concertData?.sessions || []}
-                    refundPolicy={concertData?.refundPolicy || ""}
-                    sessionTicketData={sessionTicketData || []}
-                  />
-                )}
-                {/* 購票人資訊 */}
-                {buyTicketStep === "insertBuyerInfo" && <InsertBuyerInfoSection />}
-                {buyTicketStep === "confirmOrder" && <ConfirmOrderSection concertData={concertData} totalPrice={totalPrice} />}
-              </div>
-            </div>
-          </>
-        )}
+          </div>
+          <div className="relative h-[350px] w-full">
+            <img src={concertData.imgBanner} alt={concertData.conTitle} className="h-full w-full object-cover" />
+          </div>
+          <div className="my-4">{buyTicketStep === "chooseSession" ? <BeforeBuyTicket /> : <PrecautionAndNeedtoKnow />}</div>
+        </div>
+        <div className="col-span-1 h-[30%] space-y-2 lg:px-3">
+          <div className="flex justify-center gap-2">
+            {/* 場次選擇 */}
+            {buyTicketStep === "chooseSession" && (
+              <ConcertSessionSection sessionData={concertData?.sessions || []} sessionTicketData={selectedSession?.ticketTypes || []} />
+            )}
+            {/* 購票人資訊 */}
+            {buyTicketStep === "insertBuyerInfo" && <InsertBuyerInfoSection />}
+            {buyTicketStep === "confirmOrder" && <ConfirmOrderSection concertData={concertData} totalPrice={totalPrice} />}
+          </div>
+        </div>
       </div>
       <Separator />
       <div className="flex w-[90%] justify-end">

--- a/src/pages/concerts/components/ConcertSessionSection.tsx
+++ b/src/pages/concerts/components/ConcertSessionSection.tsx
@@ -3,16 +3,8 @@ import { sessionData, sessionItem, ticketTypeItem } from "@/pages/concerts/types
 import Separator from "@/core/components/ui/separator";
 import TicketTypeAccordion from "./TicketTypeAccordion";
 import { useBuyTicketContext } from "../hook/useBuyTicketContext";
-export default function ConcertSessionSection({
-  sessionData,
-  refundPolicy,
-  sessionTicketData,
-}: {
-  sessionData: sessionData;
-  refundPolicy: string;
-  sessionTicketData: ticketTypeItem[];
-}) {
-  const { selectedSession, setSelectedSession } = useBuyTicketContext();
+export default function ConcertSessionSection({ sessionData, sessionTicketData }: { sessionData: sessionData; sessionTicketData: ticketTypeItem[] }) {
+  const { selectedSession, setSelectedSession, setSelectedTickets } = useBuyTicketContext();
   return (
     <>
       <div className="flex w-full flex-col">
@@ -25,7 +17,10 @@ export default function ConcertSessionSection({
                 key={session.sessionId}
                 variant="outline"
                 className={`flex h-full w-[120px] flex-col ${selectedSession?.sessionId === session.sessionId ? "text-secondary bg-blue-500" : ""}`}
-                onClick={() => setSelectedSession(session)}
+                onClick={() => {
+                  setSelectedTickets([]);
+                  setSelectedSession(session);
+                }}
               >
                 {session.sessionDate}
                 <span>{session.sessionStart}</span>
@@ -33,7 +28,11 @@ export default function ConcertSessionSection({
             ))}
           </div>
           <Separator />
-          <TicketTypeAccordion ticketTypes={sessionTicketData} refundPolicy={refundPolicy} />
+          {selectedSession ? (
+            <TicketTypeAccordion ticketTypes={sessionTicketData} />
+          ) : (
+            <div className="text-center text-sm text-gray-500">請先選擇場次</div>
+          )}
         </div>
       </div>
     </>

--- a/src/pages/concerts/components/InsertBuyerInfoSection.tsx
+++ b/src/pages/concerts/components/InsertBuyerInfoSection.tsx
@@ -36,20 +36,19 @@ export default function InsertCreditCardSection() {
   }).useGet(undefined, buyerSameAsMember);
 
   useEffect(() => {
-    if (!buyerSameAsMember) {
-      setBuyerInfo(defaultBuyerInfo);
-    }
-  }, [buyerSameAsMember]);
-  useEffect(() => {
-    if (data && "user" in data) {
+    if (buyerSameAsMember && data && "user" in data) {
       setBuyerInfo({
-        ...buyerInfo,
         name: data.user.name || "",
         email: data.user.email || "",
         mobilePhone: data.user.phone || "",
+        paymentMethod: buyerInfo.paymentMethod || "",
       });
     }
-  }, [data]);
+    if (!buyerSameAsMember) {
+      setBuyerInfo(defaultBuyerInfo);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [buyerSameAsMember, data]);
 
   // 處理錯誤
   useEffect(() => {

--- a/src/pages/concerts/components/TicketStepper.tsx
+++ b/src/pages/concerts/components/TicketStepper.tsx
@@ -16,7 +16,10 @@ export function TicketStepper({
   ticketTypeName: string;
 }) {
   const [count, setCount] = useState(initial);
-  const { selectedTickets, setSelectedTickets } = useBuyTicketContext();
+  const { selectedTickets, setSelectedTickets, selectedSession } = useBuyTicketContext();
+  useEffect(() => {
+    setCount(0);
+  }, [selectedSession]);
   useEffect(() => {
     if (count === 0) {
       setSelectedTickets(selectedTickets.filter((ticket) => ticket.ticketTypeId !== ticketTypeId));

--- a/src/pages/concerts/components/TicketTypeAccordion.tsx
+++ b/src/pages/concerts/components/TicketTypeAccordion.tsx
@@ -3,7 +3,7 @@ import { ticketTypeItem } from "../types/ConcertData";
 import { formatNumberToPrice } from "@/utils/formatToPrice";
 import { TicketStepper } from "./TicketStepper";
 import { formatLocalTime } from "@/utils/formatTime";
-export default function TicketTypeAccordion({ ticketTypes, refundPolicy }: { ticketTypes: ticketTypeItem[]; refundPolicy: string }) {
+export default function TicketTypeAccordion({ ticketTypes }: { ticketTypes: ticketTypeItem[] }) {
   return (
     <Accordion type="single" collapsible className="w-full">
       {ticketTypes.map((ticketType) => (
@@ -42,7 +42,7 @@ export default function TicketTypeAccordion({ ticketTypes, refundPolicy }: { tic
                   <ul className="list-disc pl-6">
                     <li className="font-semibold">入場方式: {ticketType.entranceType}</li>
                     <li className="font-semibold">票券權益: {ticketType.ticketBenefits}</li>
-                    <li className="font-semibold">退換票政策: {refundPolicy}</li>
+                    <li className="font-semibold">退換票政策: {ticketType.ticketRefundPolicy}</li>
                   </ul>
                 </div>
               </div>

--- a/src/pages/concerts/views/buyTickerPage.tsx
+++ b/src/pages/concerts/views/buyTickerPage.tsx
@@ -38,7 +38,7 @@ export default function Page() {
     <Layout>
       <BuyTicketProvider>
         <div className="min-h-[calc(100vh-6rem)]">
-          <BuyTicketSection concertData={concertData} concertSessionId={concertData?.sessions?.[0]?.sessionId} />
+          <BuyTicketSection concertData={concertData} />
         </div>
       </BuyTicketProvider>
     </Layout>

--- a/src/pages/user/components/ProfileInfo.tsx
+++ b/src/pages/user/components/ProfileInfo.tsx
@@ -160,6 +160,7 @@ export default function ProfileInfo({
               defaultMonth={dayjs().subtract(20, "year").startOf("year").toDate()}
               placeholder="請選擇出生年月日"
               disabled={isPending}
+              disableFuture
             />
           </div>
           <div className="flex h-[40px] items-center">
@@ -282,7 +283,7 @@ export default function ProfileInfo({
                     {isInertVerifyCode ? (
                       <>
                         <ModalVerifyEmail active={isInertVerifyCode} setIsInertVerifyCode={setIsInertVerifyCode}>
-                          <div className="mb-2 block flex flex-col items-center lg:hidden">
+                          <div className="mb-2 flex flex-col items-center">
                             <Input
                               height={40}
                               type="text"

--- a/src/pages/user/components/TicketDetail.tsx
+++ b/src/pages/user/components/TicketDetail.tsx
@@ -1,5 +1,5 @@
 import { formatNumberToPrice } from "@/utils/formatToPrice";
-import { formatLocalTimeToDate } from "@/utils/formatTime";
+import { formatLocalTime, formatLocalTimeToDate } from "@/utils/formatTime";
 import Separator from "@/core/components/ui/separator";
 import QRCode from "react-qr-code";
 import { ticketHistoryItem, orderTicket } from "../types/ticketHistory";
@@ -23,7 +23,7 @@ export const TicketDetail = ({ ticketData, orderTicket }: TicketDetailProps) => 
               地址: <span className="ml-4 font-bold">{ticketData.concertAddress}</span>
             </p>
             <p>
-              日期: <span className="ml-4 font-bold">{ticketData.sessionDate}</span>
+              日期: <span className="ml-4 font-bold">{formatLocalTime(ticketData.sessionDate)}</span>
             </p>
             <div className="mt-4 flex items-center">
               <QRCode value={ticketData.qrCode || ""} style={{ height: "auto", width: "60%" }} />
@@ -34,7 +34,7 @@ export const TicketDetail = ({ ticketData, orderTicket }: TicketDetailProps) => 
               訂單編號<span className="ml-4 font-bold">{ticketData.orderNumber}</span>
             </p>
             <p>
-              購票日期<span className="ml-4 font-bold">{ticketData.orderCreatedAt}</span>
+              購票日期<span className="ml-4 font-bold">{formatLocalTime(ticketData.orderCreatedAt)}</span>
             </p>
             <p>
               支付方式<span className="ml-4 font-bold">信用卡</span>
@@ -49,7 +49,7 @@ export const TicketDetail = ({ ticketData, orderTicket }: TicketDetailProps) => 
             <p>
               場次／票券
               <span className="ml-4 font-bold">
-                {formatLocalTimeToDate(ticketData.sessionDate)} {ticketData.sessionStart} / {ticketData.ticketTypeName}
+                {formatLocalTimeToDate(formatLocalTime(ticketData.sessionDate))} {ticketData.sessionStart} / {ticketData.ticketTypeName}
               </span>
             </p>
             <p>

--- a/src/pages/user/components/TicketHistorySection.tsx
+++ b/src/pages/user/components/TicketHistorySection.tsx
@@ -25,7 +25,10 @@ export default function TicketHistorySection() {
   const { data, error, isLoading, refetch } = useGet();
   useEffect(() => {
     if (data && Array.isArray(data) && data[0].length > 0) {
-      setTicketHistory(data[0]);
+      const sortedData = data[0].sort((a: ticketHistoryItem, b: ticketHistoryItem) => {
+        return new Date(b.orderCreatedAt).getTime() - new Date(a.orderCreatedAt).getTime();
+      });
+      setTicketHistory(sortedData);
     }
   }, [data]);
   // 處理錯誤

--- a/src/pages/user/components/modalVerifyEmail.tsx
+++ b/src/pages/user/components/modalVerifyEmail.tsx
@@ -10,7 +10,7 @@ interface ModalVerifyEmailProps {
 
 export function ModalVerifyEmail({ children, setIsInertVerifyCode }: ModalVerifyEmailProps) {
   return (
-    <div className="fixed inset-0 z-50 my-5 flex items-center justify-center bg-black/50">
+    <div className="fixed inset-0 z-50 my-5 block flex items-center justify-center bg-black/50 lg:hidden">
       <div className="max-h-[90vh] w-[80%] overflow-y-auto rounded-lg bg-white px-5 py-4 md:w-[30%] md:p-5">
         <div className="flex justify-end">
           <Button

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -1,4 +1,7 @@
 export const formatLocalTime = (dateString: string) => {
+  const date = new Date(dateString);
+  // 加上 8 小時 (8 * 60 * 60 * 1000 毫秒)
+  const twDate = new Date(date.getTime() + 8 * 60 * 60 * 1000);
   return new Intl.DateTimeFormat("zh-TW", {
     year: "numeric",
     month: "2-digit",
@@ -6,7 +9,7 @@ export const formatLocalTime = (dateString: string) => {
     hour: "2-digit",
     minute: "2-digit",
     hour12: false, // 使用24小時制
-  }).format(new Date(dateString));
+  }).format(twDate);
 };
 
 export const formatLocalTimeToDate = (dateString: string) => {


### PR DESCRIPTION
1. 編輯舉辦方的公司電話把電話處理拿掉
2. 驗證信箱彈跳視窗(電腦版不能顯示)
3. InterBuyerTicket  點擊checkbox, 取消後再點擊一次 會沒有將API存入buyInfo
4.票券詳細資訊: 日期 時間的轉換(UTC+0變成UTC+8小時)
5. 會員中心: 出生年月日(不能選未來日期)
6. 查看票券=>排序orderCreateTime
7. 帳號展開的選單有時不能點擊的問題
8. 會員註冊: 錯誤訊息與欄位標題重疊
9. 選擇不同場次時, 要對應不同的ticketType
10. 修正: 部屬後常見問題圖片無法顯示的問題&檔案錯誤